### PR TITLE
Fixed logs for PHP7

### DIFF
--- a/php/debian-8-php7/conf/etc/supervisor.d/php-fpm.conf
+++ b/php/debian-8-php7/conf/etc/supervisor.d/php-fpm.conf
@@ -13,7 +13,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-fpm]
-command = bash /opt/docker/bin/logwatch.sh php:fpm /var/log/php5-fpm/fpm.log
+command = bash /opt/docker/bin/logwatch.sh php:fpm /var/log/php7-fpm/fpm.log
 autostart = true
 autorestart = true
 stdout_logfile=/dev/stdout
@@ -22,7 +22,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-slow]
-command = bash /opt/docker/bin/logwatch.sh php:slow /var/log/php5-fpm/slow.log
+command = bash /opt/docker/bin/logwatch.sh php:slow /var/log/php7-fpm/slow.log
 autostart = true
 autorestart = true
 stdout_logfile=/dev/stdout
@@ -31,7 +31,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-error]
-command = bash /opt/docker/bin/logwatch.sh php:error /var/log/php5-fpm/error.log
+command = bash /opt/docker/bin/logwatch.sh php:error /var/log/php7-fpm/error.log
 autostart = true
 autorestart = true
 stdout_logfile=/dev/stdout
@@ -40,7 +40,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-access]
-command = bash /opt/docker/bin/logwatch.sh php:access /var/log/php5-fpm/access.log
+command = bash /opt/docker/bin/logwatch.sh php:access /var/log/php7-fpm/access.log
 autostart = true
 autorestart = true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
debian-8-php7 has incorrect path for php7-fpm logs   : 

```
main_1 | tail: cannot open ‘/var/log/php5-fpm/access.log’ for reading: No such file or directory
main_1 | tail: cannot watch parent directory of ‘/var/log/php5-fpm/access.log’: No such file or directory
main_1 | tail: inotify cannot be used, reverting to polling
main_1 | tail: no files remaining
main_1 | tail: cannot open ‘/var/log/php5-fpm/slow.log’ for reading: No such file or directory
main_1 | tail: cannot watch parent directory of ‘/var/log/php5-fpm/slow.log’: No such file or directory
main_1 | tail: inotify cannot be used, reverting to polling
main_1 | tail: no files remaining
main_1 | 2016-01-03 14:47:37,081 INFO exited: php-fpm-log-slow (exit status 1; not expected)
```

```
docker-compose run main ls -laF /var/log/php7-fpm
total 8
drwxr-xr-x  2 root root 4096 Dec 30 19:26 ./
drwxr-xr-x 13 root root 4096 Dec 30 19:37 ../
-rw-------  1 root root    0 Dec 30 19:26 access.log
-rw-------  1 root root    0 Dec 30 19:26 error.log
-rw-------  1 root root    0 Dec 30 19:26 fpm.log
-rw-------  1 root root    0 Dec 30 19:26 slow.log