### PR TITLE
Create PHP AUDIT Container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ bootstrap: webdevops/bootstrap webdevops/ansible
 base:      webdevops/base webdevops/base-app webdevops/storage
 service:   webdevops/ssh webdevops/vsftp webdevops/postfix
 
-php:       webdevops/php webdevops/php-apache webdevops/php-nginx
+php:       webdevops/php webdevops/php-audit webdevops/php-apache webdevops/php-nginx
 hhvm:      webdevops/hhvm webdevops/hhvm-apache webdevops/hhvm-nginx
 
 web:       webdevops/apache webdevops/nginx
@@ -80,6 +80,9 @@ webdevops/base-app:
 
 webdevops/php:
 	bash bin/build.sh php "${DOCKER_REPOSITORY}/php" "${DOCKER_TAG_LATEST}"
+
+webdevops/php-audit:
+	bash bin/build.sh php-audit "${DOCKER_REPOSITORY}/php-audit" "${DOCKER_TAG_LATEST}"
 
 webdevops/apache:
 	bash bin/build.sh apache "${DOCKER_REPOSITORY}/apache" "${DOCKER_TAG_LATEST}"

--- a/docker/php-audit/README.md
+++ b/docker/php-audit/README.md
@@ -1,0 +1,25 @@
+# PHP tools container for static analyse
+Container                                 | Distribution name        | PHP Version                                                               
+----------------------------------------- | -------------------------|---------------
+`webdevops/php-audit:debian-7`            | wheezy                   | PHP 5.4
+`webdevops/php-audit:debian-8`            | jessie                   | PHP 5.6
+`webdevops/php-audit:debian-8-php7`       | jessie with dotdeb       | PHP 7.x (via dotdeb)
+`webdevops/php-audit:debian-9`            |                          | PHP 5.x
+`webdevops/php-audit:debian-9-php7`       |                          | PHP 7.x
+`webdevops/php-audit:centos-7`            |                          | PHP 5.4
+`webdevops/php-audit:centos-7-php56`      |                          | PHP 5.6 (via webtatic)
+`webdevops/php-audit:centos-7-php7`       |                          | PHP 7.0 (via webtatic)
+`webdevops/php-audit:alpine-3`            |                          | PHP 5.6 
+
+## Available tools
+
+- [PHPLoc](https://github.com/sebastianbergmann/phploc) 
+- [PHP Depend](https://pdepend.org/) 
+- [PHPUnit](https://phpunit.de/) 
+- [PHP Mess Detector](https://phpmd.org/) 
+- [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 
+- [PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd) 
+- [PHP Dead Code Detector](https://github.com/sebastianbergmann/phpdcd) 
+- [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) 
+- [SensioLabs DeprecationDetector](https://github.com/sensiolabs-de/deprecation-detector)
+- [PHP 7 Compatibility Checker](https://github.com/sstalle/php7cc)

--- a/docker/php-audit/README.md
+++ b/docker/php-audit/README.md
@@ -23,3 +23,10 @@ Container                                 | Distribution name        | PHP Versi
 - [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) 
 - [SensioLabs DeprecationDetector](https://github.com/sensiolabs-de/deprecation-detector)
 - [PHP 7 Compatibility Checker](https://github.com/sstalle/php7cc)
+
+## Usage
+
+```sh
+docker pull webdevops/php-audit
+docker run -ti -v $(pwd):/project webdevops/php-audit phploc src/
+```

--- a/docker/php-audit/alpine-3/Dockerfile
+++ b/docker/php-audit/alpine-3/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/alpine-3/Dockerfile
+++ b/docker/php-audit/alpine-3/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:alpine-3
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apk-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/centos-7-php56/Dockerfile
+++ b/docker/php-audit/centos-7-php56/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/centos-7-php56/Dockerfile
+++ b/docker/php-audit/centos-7-php56/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM infogene/php:centos-7-php56
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/yum-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/centos-7-php7/Dockerfile
+++ b/docker/php-audit/centos-7-php7/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/centos-7-php7/Dockerfile
+++ b/docker/php-audit/centos-7-php7/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM infogene/php:centos-7-php7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/yum-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/centos-7/Dockerfile
+++ b/docker/php-audit/centos-7/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:centos-7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/yum-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/centos-7/Dockerfile
+++ b/docker/php-audit/centos-7/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-7-php7/Dockerfile.disable
+++ b/docker/php-audit/debian-7-php7/Dockerfile.disable
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-7-php7/Dockerfile.disable
+++ b/docker/php-audit/debian-7-php7/Dockerfile.disable
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-7-php7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/debian-7/Dockerfile
+++ b/docker/php-audit/debian-7/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-7/Dockerfile
+++ b/docker/php-audit/debian-7/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/debian-8-php7/Dockerfile
+++ b/docker/php-audit/debian-8-php7/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-8-php7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/debian-8-php7/Dockerfile
+++ b/docker/php-audit/debian-8-php7/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-8/Dockerfile
+++ b/docker/php-audit/debian-8/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-8/Dockerfile
+++ b/docker/php-audit/debian-8/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-8
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/debian-9-php7/Dockerfile
+++ b/docker/php-audit/debian-9-php7/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-9-php7
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/docker/php-audit/debian-9-php7/Dockerfile
+++ b/docker/php-audit/debian-9-php7/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-9/Dockerfile
+++ b/docker/php-audit/debian-9/Dockerfile
@@ -23,4 +23,7 @@ RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmo
 	&& chmod +x /usr/local/bin/deprecation-detector \
 	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
 
+WORKDIR /project
+VOLUME  /project
+
 CMD ["noop"]

--- a/docker/php-audit/debian-9/Dockerfile
+++ b/docker/php-audit/debian-9/Dockerfile
@@ -1,0 +1,26 @@
+#++++++++++++++++++++++++++++++++++++++
+# CentOS 7 PHP Docker container
+#++++++++++++++++++++++++++++++++++++++
+
+FROM webdevops/php:debian-9
+MAINTAINER guillaume.camus@gmail.com
+LABEL vendor=infogene \
+	version=1.0 
+
+RUN /usr/local/bin/apt-install \
+		graphviz 
+RUN curl -o /usr/local/bin/phploc -L https://phar.phpunit.de/phploc.phar && chmod +x /usr/local/bin/phploc \
+	&& curl -o /usr/local/bin/phpunit -L https://phar.phpunit.de/phpunit.phar && chmod +x /usr/local/bin/phpunit \
+	&& curl -o /usr/local/bin/pdepend -L http://static.pdepend.org/php/latest/pdepend.phar && chmod +x /usr/local/bin/pdepend \
+	&& curl -o /usr/local/bin/phpmd -L http://static.phpmd.org/php/latest/phpmd.phar && chmod +x /usr/local/bin/phpmd \
+	&& curl -o /usr/local/bin/phpcs -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs \
+	&& curl -o /usr/local/bin/phpcbf -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar && chmod +x /usr/local/bin/phpcbf \
+	&& curl -o /usr/local/bin/phpcpd -L https://phar.phpunit.de/phpcpd.phar && chmod +x /usr/local/bin/phpcpd \
+	&& curl -o /usr/local/bin/phpdcd -L https://phar.phpunit.de/phpdcd.phar && chmod +x /usr/local/bin/phpdcd \
+	&& curl -o /usr/local/bin/phpmetrics -L https://github.com/Halleck45/PhpMetrics/raw/master/build/phpmetrics.phar && chmod +x /usr/local/bin/phpmetrics \
+	&& curl -o /usr/local/bin/php-cs-fixer -L http://get.sensiolabs.org/php-cs-fixer.phar && chmod +x /usr/local/bin/php-cs-fixer \
+	&& curl -o /usr/local/bin/deprecation-detector -L https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar \
+	&& chmod +x /usr/local/bin/deprecation-detector \
+	&& COMPOSER_HOME="/usr/local/composer" COMPOSER_BIN_DIR="/usr/local/bin" composer global require "sstalle/php7cc"
+
+CMD ["noop"]

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,6 +24,9 @@ base-app:
 php:
 	bash ./run.sh php
 
+php-audit:
+	bash ./run.sh php-audit
+
 apache:
 	bash ./run.sh apache
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -338,6 +338,47 @@ initEnvironment
 }
 
 #######################################
+# infogene/php
+#######################################
+
+[[ $(checkTestTarget php-audit) ]] && {
+    setupTestEnvironment "php-audit"
+
+    ##########
+    # PHP 5
+    ##########
+
+    setSpecTest "php5-audit"
+    
+    setEnvironmentOsFamily "redhat"
+    OS_VERSION="7" runTestForTag "centos-7"
+    OS_VERSION="7" runTestForTag "centos-7-php56"
+    
+    setEnvironmentOsFamily "debian"
+    OS_VERSION="7" runTestForTag "debian-7"
+    OS_VERSION="8" runTestForTag "debian-8"
+    OS_VERSION="testing" runTestForTag "debian-9"
+
+    setEnvironmentOsFamily "alpine"
+    OS_VERSION="3" runTestForTag "alpine-3"
+
+    ##########
+    # PHP 7
+    ##########
+
+    setSpecTest "php7-audit"
+
+    setEnvironmentOsFamily "redhat"
+    OS_VERSION="7" runTestForTag "centos-7-php7"
+    
+    setEnvironmentOsFamily "debian"
+    OS_VERSION="8" runTestForTag "debian-8-php7"
+    OS_VERSION="testing" runTestForTag "debian-9-php7"
+
+    waitForTestRun
+}
+
+#######################################
 # webdevops/apache
 #######################################
 

--- a/test/spec/collection/php-audit.rb
+++ b/test/spec/collection/php-audit.rb
@@ -1,0 +1,6 @@
+shared_examples 'collection::php-audit' do
+    
+    include_examples 'php::audit'
+    include_examples 'misc::graphviz'
+
+end

--- a/test/spec/docker/php5-audit_spec.rb
+++ b/test/spec/docker/php5-audit_spec.rb
@@ -1,0 +1,17 @@
+require 'serverspec'
+require 'docker'
+require 'spec_helper'
+
+describe "Dockerfile" do
+    before(:all) do
+        image = Docker::Image.build_from_tar(File.new(ENV['DOCKERFILE'], 'r'))
+        set :docker_image, image.id
+    end
+
+    include_examples 'collection::bootstrap'
+    include_examples 'collection::base'
+    include_examples 'collection::base-app'
+    include_examples 'collection::php5'
+    include_examples 'collection::php-audit'
+
+end

--- a/test/spec/docker/php7-audit_spec.rb
+++ b/test/spec/docker/php7-audit_spec.rb
@@ -1,0 +1,17 @@
+require 'serverspec'
+require 'docker'
+require 'spec_helper'
+
+describe "Dockerfile" do
+    before(:all) do
+        image = Docker::Image.build_from_tar(File.new(ENV['DOCKERFILE'], 'r'))
+        set :docker_image, image.id
+    end
+
+    include_examples 'collection::bootstrap'
+    include_examples 'collection::base'
+    include_examples 'collection::base-app'
+    include_examples 'collection::php7'
+    include_examples 'collection::php-audit'
+
+end

--- a/test/spec/shared/misc/tools.rb
+++ b/test/spec/shared/misc/tools.rb
@@ -9,3 +9,10 @@ shared_examples 'misc::imagemagick' do
         expect(file("/usr/bin/convert")).to be_executable
     end
 end
+
+
+shared_examples 'misc::graphviz' do
+    it "should include graphviz" do
+        expect(file("/usr/bin/dot")).to be_executable
+    end
+end

--- a/test/spec/shared/php/audit.rb
+++ b/test/spec/shared/php/audit.rb
@@ -1,0 +1,30 @@
+shared_examples 'php::audit' do
+
+	[
+        "/usr/local/bin/composer",
+        "/usr/local/bin/phploc",
+        "/usr/local/bin/pdepend",
+        "/usr/local/bin/phpmd",
+        "/usr/local/bin/phpcs",
+        "/usr/local/bin/phpcbf",
+        "/usr/local/bin/phpcpd",
+        "/usr/local/bin/phpdcd",
+        "/usr/local/bin/phpmetrics",
+        "/usr/local/bin/php-cs-fixer",
+        "/usr/local/bin/deprecation-detector",
+        "/usr/local/bin/php7cc",
+        "/usr/local/bin/phpunit"
+
+    ].each do |file|
+
+    	describe file("#{file}") do 
+    		it { should be_file }
+    		it { should be_executable }
+    	end
+
+    	describe command('#{file}') do
+	        its(:exit_status) { should eq 0 }
+	    end
+	    
+    end
+end


### PR DESCRIPTION
For the issue #25 

i work on a container that extend webdevops/php and add many tools to audit php code :

- phploc
- pdepend
- phpunit
- phpmd
- phpcs
- phpcbf
- phpcpd
- phpdcd
- phpmetrics
- php-cs-fixer
- deprecation-detector (for symfony)
- php7cc
