### PR TITLE
Fixed a minor issue

### DIFF
--- a/docker/php/alpine-3-php7/conf/etc/supervisor.d/php-fpm.conf
+++ b/docker/php/alpine-3-php7/conf/etc/supervisor.d/php-fpm.conf
@@ -14,7 +14,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-fpm]
-command = bash /opt/docker/bin/logwatch.sh php:fpm /var/log/php5-fpm/fpm.log
+command = bash /opt/docker/bin/logwatch.sh php:fpm /var/log/php7-fpm/fpm.log
 startsecs = 0
 autostart = true
 autorestart = true
@@ -24,7 +24,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-slow]
-command = bash /opt/docker/bin/logwatch.sh php:slow /var/log/php5-fpm/slow.log
+command = bash /opt/docker/bin/logwatch.sh php:slow /var/log/php7-fpm/slow.log
 startsecs = 0
 autostart = true
 autorestart = true
@@ -34,7 +34,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm-log-error]
-command = bash /opt/docker/bin/logwatch.sh php:error /var/log/php5-fpm/error.log
+command = bash /opt/docker/bin/logwatch.sh php:error /var/log/php7-fpm/error.log
 startsecs = 0
 autostart = true
 autorestart = true


### PR DESCRIPTION
```
test_1   | tail: can't open '/var/log/php5-fpm/slow.log': No such file or directory
test_1   | tail: can't open '/var/log/php5-fpm/access.log': No such file or directory
test_1   | tail: can't open '/var/log/php5-fpm/error.log': No such file or directory
test_1   | tail: can't open '/var/log/php5-fpm/fpm.log': No such file or directory
```