### PR TITLE
Add clear env workaround for FPM

### DIFF
--- a/docker/php/alpine-3-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/alpine-3-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/alpine-3-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/alpine-3-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/alpine-3/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/alpine-3/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/alpine-3/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/alpine-3/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/alpine-3/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/alpine-3/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/centos-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/centos-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/centos-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/centos-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/centos-7/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/centos-7/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/debian-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/debian-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/debian-7/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/debian-7/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/debian-8-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-8-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/debian-8-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-8-php7/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/debian-8/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-8/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/debian-8/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-8/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/debian-8/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/debian-8/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/debian-9/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-9/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/debian-9/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/debian-9/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/ubuntu-12.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-12.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/ubuntu-12.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-12.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/ubuntu-12.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/ubuntu-12.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/ubuntu-14.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-14.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/ubuntu-14.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-14.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/ubuntu-14.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/ubuntu-14.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/ubuntu-15.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-15.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/ubuntu-15.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-15.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/ubuntu-15.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/ubuntu-15.04/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/ubuntu-15.10/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-15.10/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/ubuntu-15.10/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-15.10/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/docker/php/ubuntu-15.10/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/docker/php/ubuntu-15.10/conf/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:

--- a/docker/php/ubuntu-16.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-16.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                if [[ -n "$envVariableContent" ]]; then
+
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/docker/php/ubuntu-16.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/docker/php/ubuntu-16.04/conf/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -16,8 +16,8 @@ for envVariable in $(printenv|cut -f1 -d=); do
                 ## get content of variable
                 envVariableContent="${!envVariable}"
 
+                ## php-fpm requires that env variable has to be filled with content
                 if [[ -n "$envVariableContent" ]]; then
-
                     ## quote quotes
                     envVariableContent=${envVariableContent//\"/\\\"}
 
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/provisioning/php/general/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/provisioning/php/general/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -1,0 +1,33 @@
+#
+# Workaround for old php-fpm versions which don't have clear_env setting
+#
+
+VARIABLE_LIST="; Workaround for missing clear_env feature in PHP-FPM"
+
+# For each exported variable
+for envVariable in $(printenv|cut -f1 -d=); do
+
+    case "$envVariable" in
+        "_"|"PATH"|"PWD")
+            ## ignore this variables
+            ;;
+
+        *)
+                ## get content of variable
+                envVariableContent="${!envVariable}"
+
+                ## php-fpm requires that env variable has to be filled with content
+                if [[ -n "$envVariableContent" ]]; then
+                    ## quote quotes
+                    envVariableContent=${envVariableContent//\"/\\\"}
+
+                    ## add to list
+                    VARIABLE_LIST="${VARIABLE_LIST}"$'\n'"env[${envVariable}] = \"${envVariableContent}\""
+                fi
+                ;;
+    esac
+
+done
+
+find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
+

--- a/provisioning/php/general/bin/service.d/php-fpm.d/11-clear-env.sh
+++ b/provisioning/php/general/bin/service.d/php-fpm.d/11-clear-env.sh
@@ -29,5 +29,6 @@ for envVariable in $(printenv|cut -f1 -d=); do
 
 done
 
+# Replace ;#CLEAR_ENV_WORKAROUND# with environment variable list for all php-fpm pool files
 find /opt/docker/etc/php/fpm/pool.d/ -iname '*.conf' -print0 | xargs -0 -r rpl --quiet ";#CLEAR_ENV_WORKAROUND#" "$VARIABLE_LIST" > /dev/null
 

--- a/provisioning/php/general/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
+++ b/provisioning/php/general/provision/roles/webdevops-php/tasks/bootstrap/php-fpm.pool.yml
@@ -13,6 +13,15 @@
 - debug:
     msg: "PHP-Version: {{php_version}}"
 
+- set_fact:
+     php_clear_env_available: False
+
+- set_fact:
+     php_clear_env_available: True
+  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
+        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
+        ( php_version | version_compare('5.6', 'ge') )
+
 - name: Set php pool file
   set_fact:
      php_pool_conf: www.conf
@@ -76,10 +85,19 @@
     line:   '{{ item.key }} = {{ item.value }}'
   with_items:
    - { key: 'clear_env', value: "no" }
-  when: ( php_version | version_compare('5.4', 'eq') and php_version | version_compare('5.4.27', 'ge') ) or
-        ( php_version | version_compare('5.5', 'eq') and php_version | version_compare('5.5.11', 'ge') ) or
-        ( php_version | version_compare('5.6', 'ge') )
+  when: php_clear_env_available == True
 
+- name: Remove clear env workaround
+  file:
+    path: "/opt/docker/bin/service.d/php-fpm.d/11-clear-env.sh"
+    state: absent
+  when: php_clear_env_available == True
+
+- name: Append clear env workaround in php-fpm pool (old php-fpm versions)
+  lineinfile:
+    dest:   '/opt/docker/etc/php/fpm/pool.d/application.conf'
+    line:   ';#CLEAR_ENV_WORKAROUND#'
+  when: php_clear_env_available == False
 
 - name: Disable php-fpm connection limit
   lineinfile:


### PR DESCRIPTION
Some PHP versions are missing the clear_env=no feature so this is a workaround for it
Related: #86