### PR TITLE
Debian 8 with working PHP7

### DIFF
--- a/docker/php-dev/debian-8-php7/Dockerfile.jinja2
+++ b/docker/php-dev/debian-8-php7/Dockerfile.jinja2
@@ -4,4 +4,4 @@
 
 {{ docker.copy('conf/', '/opt/docker/') }}
 
-{{ php7dev.debianDotDeb() }}
+{{ php7dev.debianSury() }}

--- a/docker/php/debian-8-php7/Dockerfile
+++ b/docker/php/debian-8-php7/Dockerfile
@@ -17,9 +17,19 @@ ENV WEB_ALIAS_DOMAIN   *.vm
 COPY conf/ /opt/docker/
 
 # Install php environment
-RUN echo "deb http://packages.dotdeb.org jessie all" >> /etc/apt/sources.list \
-    && echo "deb-src http://packages.dotdeb.org jessie all" >> /etc/apt/sources.list \
-    && wget -O- https://www.dotdeb.org/dotdeb.gpg | apt-key add  - \
+RUN /usr/local/bin/apt-install apt-transport-https lsb-release \
+    && echo "deb https://packages.sury.org/php/ jessie main" >> /etc/apt/sources.list \
+    && echo "deb http://ftp2.de.debian.org/debian/ testing main" >> /etc/apt/sources.list \
+    && echo "deb-src http://ftp2.de.debian.org/debian/ testing main" >> /etc/apt/sources.list \
+    && wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - \
+    && echo "Package: *" > /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Pin: origin ftp2.de.debian.org" >> /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Pin-Priority: -10" >> /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Package: libpcre3" > /etc/apt/preferences.d/libpcre.pref \
+    && echo "Pin: release a=testing" >> /etc/apt/preferences.d/libpcre.pref \
+    && echo "Pin-Priority: 995" >> /etc/apt/preferences.d/libpcre.pref \
+    && apt-get update \
+    && apt-get -t testing install -y -f libpcre3 \
     && /usr/local/bin/apt-install \
         # Install tools
         imagemagick \

--- a/docker/php/debian-8-php7/Dockerfile.jinja2
+++ b/docker/php/debian-8-php7/Dockerfile.jinja2
@@ -6,6 +6,6 @@
 
 {{ docker.copy('conf/', '/opt/docker/') }}
 
-{{ php7.debianDotDeb('jessie') }}
+{{ php7.debianSury('jessie') }}
 
 {{ docker.expose('9000') }}

--- a/template/Dockerfile/images/php7-dev.jinja2
+++ b/template/Dockerfile/images/php7-dev.jinja2
@@ -32,16 +32,15 @@ RUN /usr/local/bin/apt-install \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
-{% macro debianDotDeb(role='') -%}
+{% macro debianSury(role='') -%}
 # Install development environment
 RUN /usr/local/bin/apt-install \
         # Install tools
         graphviz \
         # Install php development stuff
-        php7.0-xdebug \
+        # php7.0-xdebug \ # Is currently not available
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
-
 
 {% macro ubuntu(role='') -%}
 # Install development environment

--- a/template/Dockerfile/images/php7.jinja2
+++ b/template/Dockerfile/images/php7.jinja2
@@ -63,12 +63,20 @@ RUN /usr/local/bin/apk-install \
     {{ provision.runRoleInline('php', role) }}
 {%- endmacro %}
 
-
-{% macro debianDotDeb(distribution,role='') -%}
-# Install php environment
-RUN echo "deb http://packages.dotdeb.org {{ distribution }} all" >> /etc/apt/sources.list \
-    && echo "deb-src http://packages.dotdeb.org {{ distribution }} all" >> /etc/apt/sources.list \
-    && wget -O- https://www.dotdeb.org/dotdeb.gpg | apt-key add  - \
+{% macro debianSury(distribution,role='') -%}
+RUN /usr/local/bin/apt-install apt-transport-https lsb-release \
+    && echo "deb https://packages.sury.org/php/ {{ distribution }} main" >> /etc/apt/sources.list \
+    && echo "deb http://ftp2.de.debian.org/debian/ testing main" >> /etc/apt/sources.list \
+    && echo "deb-src http://ftp2.de.debian.org/debian/ testing main" >> /etc/apt/sources.list \
+    && wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - \
+    && echo "Package: *" > /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Pin: origin ftp2.de.debian.org" >> /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Pin-Priority: -10" >> /etc/apt/preferences.d/debian_testing.pref \
+    && echo "Package: libpcre3" > /etc/apt/preferences.d/libpcre.pref \
+    && echo "Pin: release a=testing" >> /etc/apt/preferences.d/libpcre.pref \
+    && echo "Pin-Priority: 995" >> /etc/apt/preferences.d/libpcre.pref \
+    && apt-get update \
+    && apt-get -t testing install -y -f libpcre3 \
     && /usr/local/bin/apt-install \
         # Install tools
         imagemagick \
@@ -93,7 +101,6 @@ RUN echo "deb http://packages.dotdeb.org {{ distribution }} all" >> /etc/apt/sou
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer \
     {{ provision.runRoleInline('php', role) }}
 {%- endmacro %}
-
 
 {% macro debian9(role='') -%}
 # Install php environment


### PR DESCRIPTION
Switch from dotdeb to sury repository and install libpcre3 from testing
to get a running PHP7 without SIGABRT or SIGSEGV in TYPO3.