### PR TITLE
:sparkles: :books: Add xdebug and blackfire environment variables

### DIFF
--- a/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-apache-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-apache-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/centos-7-php56/Dockerfile
+++ b/docker/php-dev/centos-7-php56/Dockerfile
@@ -19,6 +19,7 @@ RUN wget -O - "https://packages.blackfire.io/fedora/blackfire.repo" | tee /etc/y
         # Install php development stuff
         php56w-pecl-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/centos-7/Dockerfile
+++ b/docker/php-dev/centos-7/Dockerfile
@@ -20,6 +20,7 @@ RUN wget -O - "https://packages.blackfire.io/fedora/blackfire.repo" | tee /etc/y
         # Install php development stuff
         php-pecl-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/debian-7/Dockerfile
+++ b/docker/php-dev/debian-7/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/debian-8-php7/Dockerfile
+++ b/docker/php-dev/debian-8-php7/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         # php7.0-xdebug \ # Is currently not available
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/debian-8/Dockerfile
+++ b/docker/php-dev/debian-8/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/debian-9/Dockerfile
+++ b/docker/php-dev/debian-9/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/ubuntu-12.04/Dockerfile
+++ b/docker/php-dev/ubuntu-12.04/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/ubuntu-14.04/Dockerfile
+++ b/docker/php-dev/ubuntu-14.04/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/ubuntu-15.04/Dockerfile
+++ b/docker/php-dev/ubuntu-15.04/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/ubuntu-15.10/Dockerfile
+++ b/docker/php-dev/ubuntu-15.10/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-dev/ubuntu-16.04/Dockerfile
+++ b/docker/php-dev/ubuntu-16.04/Dockerfile
@@ -21,6 +21,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php-xdebug \
         blackfire-php \
+        blackfire-agent \
     && /opt/docker/bin/provision run --tag bootstrap --role webdevops-php-dev \
     && /opt/docker/bin/bootstrap.sh
 

--- a/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/alpine-3/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/centos-7-php56/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/centos-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/centos-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/debian-7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/debian-8-php7/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/debian-8/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-8/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/debian-9/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/debian-9/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/documentation/docs/content/DockerImages/dockerfiles/include/environment-php-dev.rst
+++ b/documentation/docs/content/DockerImages/dockerfiles/include/environment-php-dev.rst
@@ -1,13 +1,25 @@
-========================== ============================ ==============================================
-Environment variable       Description                  Default
-========================== ============================ ==============================================
-``WEB_DOCUMENT_ROOT``      Document root for webserver  ``/app``
-``WEB_DOCUMENT_INDEX``     Index document               ``index.php``
-``WEB_ALIAS_DOMAIN``       Domain aliases               ``*.vm``
-``WEB_PHP_SOCKET``         PHP-FPM socket address       ``127.0.0.1:9000`` (for php-* images)
-``WEB_NO_CACHE_PATTERN``   RegExp of files which should ``\.(css|js|gif|png|jpg|svg|json|xml)$``
-                           be delivered by webserver as
-                           non cacheable to browser
-``PHP_DEBUGGER``           Specifies which php debugger *empty* (eg. ``xdebug``, ``blackfire`` or
-                           should be active             ``none``)
-========================== ============================ ==============================================
+====================================== ===================================== ==============================================
+Environment variable                    Description                          Default
+====================================== ===================================== ==============================================
+``WEB_DOCUMENT_ROOT``                  Document root for webserver           ``/app``
+``WEB_DOCUMENT_INDEX``                 Index document                        ``index.php``
+``WEB_ALIAS_DOMAIN``                   Domain aliases                        ``*.vm``
+``WEB_PHP_SOCKET``                     PHP-FPM socket address                ``127.0.0.1:9000`` (for php-* images)
+``WEB_NO_CACHE_PATTERN``               RegExp of files which should          ``\.(css|js|gif|png|jpg|svg|json|xml)$``
+                                       be delivered by webserver as
+                                       non cacheable to browser
+``PHP_DEBUGGER``                       Specifies which php debugger          *empty* (eg. ``xdebug``, ``blackfire`` or
+                                       should be active                      ``none``)
+``XDEBUG_REMOTE_AUTOSTART``            php.ini value for                     ``none``
+                                       ``xdebug.remote_autostart``
+``XDEBUG_REMOTE_CONNECT_BACK``         php.ini value for                     ``none``
+                                       ``xdebug.remote_connect_back``
+``XDEBUG_REMOTE_HOST``                 php.ini value for                     ``none``
+                                       ``xdebug.remote_host``
+``XDEBUG_REMOTE_PORT``                 php.ini value for                     ``none``
+                                       ``xdebug.remote_port``
+``BLACKFIRE_SERVER_ID``                php.ini value for                     ``none``
+                                       ``blackfire.server_id``
+``BLACKFIRE_SERVER_TOKEN``             php.ini value for                     ``none``
+                                       ``blackfire.server_token``
+====================================== ===================================== ==============================================

--- a/provisioning/php-dev/general/bin/service.d/blackfire-agent.d/10-init.sh
+++ b/provisioning/php-dev/general/bin/service.d/blackfire-agent.d/10-init.sh
@@ -1,0 +1,1 @@
+# placeholder

--- a/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
+++ b/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/docker/bin/config.sh
+
+BLACKFIRE_ARGS=""
+
+includeScriptDir "/opt/docker/bin/service.d/syslog-ng.d/"
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-id=\"${BLACKFIRE_SERVER_ID}\""
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
+fi
+
+exec blackfire-agent $BLACKFIRE_ARGS

--- a/provisioning/php-dev/general/etc/supervisor.d/blackfire-agent.conf
+++ b/provisioning/php-dev/general/etc/supervisor.d/blackfire-agent.conf
@@ -1,0 +1,14 @@
+[group:blackfire-agent]
+programs=blackfire-agentd
+priority=25
+
+[program:blackfire-agentd]
+command = /opt/docker/bin/service.d/blackfire-agent.sh
+process_name=%(program_name)s
+startsecs = 0
+autostart = false
+autorestart = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/provisioning/php-dev/general/provision/entrypoint.d/10-php-debugger.sh
+++ b/provisioning/php-dev/general/provision/entrypoint.d/10-php-debugger.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-#
+
+#################################################
 # Debugger switch
-#
+#################################################
 
 PHP_CONF_PATHS="
 /etc/php5/conf.d
@@ -53,4 +54,53 @@ else
     echo "PHP-Debugger: not specified - default is xdebug"
     phpModuleRemove "blackfire"
 
+fi
+
+#################################################
+# PHP debugger environment variables
+#################################################
+
+function phpEnvironmentVariable() {
+    PHP_ENV_NAME="$1"
+    PHP_ENV_VALUE="$2"
+
+    echo "${PHP_ENV_NAME}=\"${PHP_ENV_VALUE}\"" >> /opt/docker/etc/php/php.ini
+}
+
+###################
+# XDEBUG
+###################
+
+# xdebug.remote_connect_back
+if [[ -n "${XDEBUG_REMOTE_CONNECT_BACK+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_connect_back" "$XDEBUG_REMOTE_CONNECT_BACK"
+fi
+
+# xdebug.remote_autostart
+if [[ -n "${XDEBUG_REMOTE_AUTOSTART+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_autostart" "$XDEBUG_REMOTE_AUTOSTART"
+fi
+
+# xdebug.remote_host
+if [[ -n "${XDEBUG_REMOTE_HOST+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_host" "$XDEBUG_REMOTE_HOST"
+fi
+
+# xdebug.remote_port
+if [[ -n "${XDEBUG_REMOTE_PORT+x}" ]]; then
+    phpEnvironmentVariable "xdebug.remote_port" "$XDEBUG_REMOTE_PORT"
+fi
+
+###################
+# BLACKFIRE
+###################
+
+# blackfire.server_id
+if [[ -n "${BLACKFIRE_SERVER_ID+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_id" "$BLACKFIRE_SERVER_ID"
+fi
+
+# blackfire.server_token
+if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
+    phpEnvironmentVariable "blackfire.server_token" "$BLACKFIRE_SERVER_TOKEN"
 fi

--- a/provisioning/php-dev/general/provision/entrypoint.d/10-php-debugger.sh
+++ b/provisioning/php-dev/general/provision/entrypoint.d/10-php-debugger.sh
@@ -40,6 +40,7 @@ if [[ -n "${PHP_DEBUGGER+x}" ]]; then
         blackfire)
             echo "PHP-Debugger: Blackfire enabled"
             phpModuleRemove "xdebug"
+            /opt/docker/bin/control.sh service.enable blackfire-agent
             ;;
 
         none)

--- a/template/Dockerfile/images/php5-dev.jinja2
+++ b/template/Dockerfile/images/php5-dev.jinja2
@@ -20,6 +20,7 @@ RUN wget -O - "https://packages.blackfire.io/fedora/blackfire.repo" | tee /etc/y
         # Install php development stuff
         php-pecl-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -31,6 +32,7 @@ RUN wget -O - "https://packages.blackfire.io/fedora/blackfire.repo" | tee /etc/y
         # Install php development stuff
         php56w-pecl-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -44,6 +46,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -58,5 +61,6 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php5-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}

--- a/template/Dockerfile/images/php7-dev.jinja2
+++ b/template/Dockerfile/images/php7-dev.jinja2
@@ -20,6 +20,7 @@ RUN wget -O - "https://packages.blackfire.io/fedora/blackfire.repo" | tee /etc/y
         # Install php development stuff
         php7-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -34,6 +35,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -47,6 +49,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php7.0-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -60,6 +63,7 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         # php7.0-xdebug \ # Is currently not available
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}
 
@@ -73,5 +77,6 @@ RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - \
         # Install php development stuff
         php-xdebug \
         blackfire-php \
+        blackfire-agent \
     {{ provision.runRoleInline('php-dev', role) }}
 {%- endmacro %}


### PR DESCRIPTION
Add following environment variables
- XDEBUG_REMOTE_CONNECT_BACK
- XDEBUG_REMOTE_AUTOSTART
- XDEBUG_REMOTE_HOST
- XDEBUG_REMOTE_PORT
- BLACKFIRE_SERVER_ID
- BLACKFIRE_SERVER_TOKEN
Fixes #113
Fixes #90