### PR TITLE
Fix blackfire-agent daemon startup

### DIFF
--- a/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-apache-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/alpine-3/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7-php56/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/centos-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8-php7/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-8/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/debian-9/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-12.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-14.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-15.10/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
+++ b/docker/php-nginx-dev/ubuntu-16.04/conf/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
+++ b/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,7 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
+# create directory for unix socket
+mkdir -p /var/run/blackfire
+
 eval exec blackfire-agent $BLACKFIRE_ARGS

--- a/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
+++ b/provisioning/php-dev/general/bin/service.d/blackfire-agent.sh
@@ -17,4 +17,4 @@ if [[ -n "${BLACKFIRE_SERVER_TOKEN+x}" ]]; then
     BLACKFIRE_ARGS="$BLACKFIRE_ARGS --server-token=\"${BLACKFIRE_SERVER_TOKEN}\""
 fi
 
-exec blackfire-agent $BLACKFIRE_ARGS
+eval exec blackfire-agent $BLACKFIRE_ARGS


### PR DESCRIPTION
$BLACKFIRE_ARGS was not getting expanded, which lead to blackfire-agent failing with 'API credentials rejected by server'. After that was fixed, the daemon still would not start because the unix socket directory did not exist. This small PR fixes both of these issues.