### PR TITLE
[BUGFIX] Fix version constraint of doit dependency

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -3,7 +3,7 @@ graphviz>=0.4.10
 cleo>=0.5.0
 yamlordereddictloader>=0.1.0
 testinfra>=1.4.2
-doit>=0.29.0
+doit==0.29.0
 termcolor>=1.1.0
 pytest-timeout>=1.0.0
 pytest-rerunfailures>=1.0.0


### PR DESCRIPTION
I'm not much into python, but I supposed the `make setup` script is ment to be run with python2, because it fails with python3:

```
[...]

  Running setup.py install for simplejson
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/local/lib/python3.4/dist-packages/setuptools/__init__.py", line 12, in <module>
        import setuptools.version
      File "/usr/local/lib/python3.4/dist-packages/setuptools/version.py", line 1, in <module>
        import pkg_resources
      File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 70, in <module>
        import packaging.version
    ImportError: No module named 'packaging'
    Complete output from command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/simplejson/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-2c8tdvo2-record/install-record.txt --single-version-externally-managed --compile:
    Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/usr/local/lib/python3.4/dist-packages/setuptools/__init__.py", line 12, in <module>

    import setuptools.version

  File "/usr/local/lib/python3.4/dist-packages/setuptools/version.py", line 1, in <module>

    import pkg_resources

  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 70, in <module>

    import packaging.version

ImportError: No module named 'packaging'

Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/simplejson/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-2c8tdvo2-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/simplejson
Storing debug log for failure in /home/tilo/.pip/pip.log
make: *** [setup] Error 1
```

With python2 `pip` informed me to use `doit==0.29.0`:

```
Downloading/unpacking doit>=0.29.0 (from -r ./bin/requirements.txt (line 6))
  Downloading doit-0.30.0.tar.gz (234kB): 234kB downloaded
  Running setup.py (path:/tmp/pip_build_root/doit/setup.py) egg_info for package doit
    This version of doit is only supported by Python 3.
    Please use doit==0.29.0 with Python 2.
    Complete output from command python setup.py egg_info:
    This version of doit is only supported by Python 3.

Please use doit==0.29.0 with Python 2.
```

So with adjusting the version constraint in the `requirements.txt` I was finally able to run make setup with success (using python2).