### PR TITLE
Use "stretch" as base for official php 7.0/7.1 builds

### DIFF
--- a/docker/php-official/5.6/Dockerfile
+++ b/docker/php-official/5.6/Dockerfile
@@ -109,7 +109,7 @@ RUN set -x \
         libldap-2.4-2 \
         libxslt1.1 \
         zlib1g \
-        libpng12-0 \
+        libpng16-16 \
         libmcrypt4 \
         libjpeg62-turbo-dev \
         libfreetype6-dev \

--- a/docker/php-official/5.6/Dockerfile.jinja2
+++ b/docker/php-official/5.6/Dockerfile.jinja2
@@ -13,7 +13,7 @@
 {{ docker.copy('conf/', '/opt/docker/') }}
 
 RUN set -x \
-    {{ bootstrap.debian('jessie') }}
+    {{ bootstrap.debian('stretch') }}
 
 RUN set -x \
     {{ base.debian() }} \
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='5.6',debian='jessie') }} \
+    {{ php.official(version='5.6') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/docker/php-official/7.0/Dockerfile
+++ b/docker/php-official/7.0/Dockerfile
@@ -109,7 +109,7 @@ RUN set -x \
         libldap-2.4-2 \
         libxslt1.1 \
         zlib1g \
-        libpng12-0 \
+        libpng16-16 \
         libmcrypt4 \
         libjpeg62-turbo-dev \
         libfreetype6-dev \

--- a/docker/php-official/7.0/Dockerfile.jinja2
+++ b/docker/php-official/7.0/Dockerfile.jinja2
@@ -13,7 +13,7 @@
 {{ docker.copy('conf/', '/opt/docker/') }}
 
 RUN set -x \
-    {{ bootstrap.debian('jessie') }}
+    {{ bootstrap.debian('stretch') }}
 
 RUN set -x \
     {{ base.debian() }} \
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='7.0',debian='jessie') }} \
+    {{ php.official(version='7.0',debian='stretch') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/docker/php-official/7.0/Dockerfile.jinja2
+++ b/docker/php-official/7.0/Dockerfile.jinja2
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='7.0',debian='stretch') }} \
+    {{ php.official(version='7.0') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/docker/php-official/7.1/Dockerfile
+++ b/docker/php-official/7.1/Dockerfile
@@ -109,7 +109,7 @@ RUN set -x \
         libldap-2.4-2 \
         libxslt1.1 \
         zlib1g \
-        libpng12-0 \
+        libpng16-16 \
         libmcrypt4 \
         libjpeg62-turbo-dev \
         libfreetype6-dev \

--- a/docker/php-official/7.1/Dockerfile.jinja2
+++ b/docker/php-official/7.1/Dockerfile.jinja2
@@ -13,7 +13,7 @@
 {{ docker.copy('conf/', '/opt/docker/') }}
 
 RUN set -x \
-    {{ bootstrap.debian('jessie') }}
+    {{ bootstrap.debian('stretch') }}
 
 RUN set -x \
     {{ base.debian() }} \
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='7.1',debian='jessie') }} \
+    {{ php.official(version='7.1',debian='stretch') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/docker/php-official/7.1/Dockerfile.jinja2
+++ b/docker/php-official/7.1/Dockerfile.jinja2
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='7.1',debian='stretch') }} \
+    {{ php.official(version='7.1') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/docker/php-official/7.2/Dockerfile.jinja2
+++ b/docker/php-official/7.2/Dockerfile.jinja2
@@ -26,7 +26,7 @@ RUN set -x \
     {{ docker.cleanup() }}
 
 RUN set -x \
-    {{ php.official(version='7.2',debian='stretch') }} \
+    {{ php.official(version='7.2') }} \
     {{ provision.runBootstrap() }} \
     {{ docker.cleanup() }}
 

--- a/template/Dockerfile/images/php.jinja2
+++ b/template/Dockerfile/images/php.jinja2
@@ -2,7 +2,7 @@
 {% import 'Dockerfile/provision.jinja2' as provision %}
 {% import 'Dockerfile/services.jinja2'  as services %}
 
-{% macro official(role='', version='',debian='') -%}
+{% macro official(role='', version='') -%}
     # Install php environment
     && apt-install \
         # Install tools
@@ -13,11 +13,7 @@
         libldap-2.4-2 \
         libxslt1.1 \
         zlib1g \
-{%- if debian == 'jessie' %}
-        libpng12-0 \
-{%- else %}
         libpng16-16 \
-{%- endif %}
         libmcrypt4 \
         libjpeg62-turbo-dev \
         libfreetype6-dev \


### PR DESCRIPTION
Fixes build issue as php:7.0-fpm and php:7.1-fpm are based on "stretch" which is missing libpng12-0.