### PR TITLE
Clear hash after pip upgrade

### DIFF
--- a/docker/dockerfile-build-env/latest/Dockerfile
+++ b/docker/dockerfile-build-env/latest/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-install \
         ruby-dev \
         ruby-bundler \
     && pip install --upgrade pip \
+    && hash -r pip \
     && pip install --upgrade setuptools \
     && pip install --upgrade \
         MarkupSafe \

--- a/docker/dockerfile-build-env/latest/Dockerfile.jinja2
+++ b/docker/dockerfile-build-env/latest/Dockerfile.jinja2
@@ -10,6 +10,7 @@ RUN apt-install \
         ruby-dev \
         ruby-bundler \
     && pip install --upgrade pip \
+    && hash -r pip \
     && pip install --upgrade setuptools \
     && pip install --upgrade \
         MarkupSafe \


### PR DESCRIPTION
Fixes build of 'dockerfile-build-env'
@see https://github.com/pypa/pip/issues/5221#issuecomment-382069604