### PR TITLE
Update documented default value for PHP_DEBUGGER

### DIFF
--- a/documentation/docs/content/DockerImages/dockerfiles/include/environment-php-dev.rst
+++ b/documentation/docs/content/DockerImages/dockerfiles/include/environment-php-dev.rst
@@ -11,7 +11,7 @@ Environment variable                          Description                       
 ``WEB_NO_CACHE_PATTERN``                      RegExp of files which should              ``\.(css|js|gif|png|jpg|svg|json|xml)$``
                                               be delivered by webserver as
                                               non cacheable to browser
-``PHP_DEBUGGER``                              Specifies which php debugger              *empty* (eg. ``xdebug``, ``blackfire`` or
+``PHP_DEBUGGER``                              Specifies which php debugger              ``xdebug`` (eg. ``xdebug``, ``blackfire`` or
                                               should be active                          ``none``)
 ``XDEBUG_REMOTE_AUTOSTART``                   php.ini value for                         ``none``
                                               ``xdebug.remote_autostart``


### PR DESCRIPTION
The default value for PHP_DEBUGGER is set in https://github.com/webdevops/Dockerfile/blob/b85975696ad58dd251c487981a821a148c72e34c/docker/php-apache-dev/centos-7-php7/conf/provision/entrypoint.d/10-php-debugger.sh#L56
and defaults to xdebug