### PR TITLE
Add missing imagick php extension

### DIFF
--- a/template/Dockerfile/images/php7.jinja2
+++ b/template/Dockerfile/images/php7.jinja2
@@ -60,6 +60,7 @@
         php7-simplexml \
         php7-tokenizer \
         php7-xmlwriter \
+        php7-imagick \
     && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
     && pecl channel-update pecl.php.net \
     && pear channel-update pear.php.net \


### PR DESCRIPTION
This PR adds php7-imagick to the alpine-php7 build. imagemagick itself was installed, just not the extension.