### PR TITLE
Correct syntax highlighting in nginx-customization

### DIFF
--- a/documentation/docs/content/DockerImages/dockerfiles/include/customization-nginx.rst
+++ b/documentation/docs/content/DockerImages/dockerfiles/include/customization-nginx.rst
@@ -4,6 +4,6 @@ Nginx customization
 This image has two directories for configuration files which will be automatic loaded.
 
 For global configuration options the directory ``/opt/docker/etc/nginx/conf.d`` can be used.
-For vhost configuration options the directory ``/opt/docker/etc/nginx/vhost.common.conf``can be used.
+For vhost configuration options the directory ``/opt/docker/etc/nginx/vhost.common.conf`` can be used.
 
 Any ``*.conf`` files inside these direcories will be included either global or the vhost section.


### PR DESCRIPTION
Need a space after the `` characters in order to properly render the code block. :)

Check it out: https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-nginx.html#nginx-customization