### PR TITLE
Upgrade liquibase to 2.6.3. Fixed duplicate migrations in <includeAll />

### DIFF
--- a/docker/liquibase/latest/Dockerfile
+++ b/docker/liquibase/latest/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer=info@webdevops.io \
       io.webdevops.layout=8 \
       io.webdevops.version=1.5.0
 
-ENV LIQUIBASE_VERSION="3.5.3" \
+ENV LIQUIBASE_VERSION="3.6.3" \
     LIQUIBASE_DRIVER="com.mysql.jdbc.Driver" \
     LIQUIBASE_CLASSPATH="/usr/share/java/mysql.jar" \
     LIQUIBASE_URL="" \

--- a/docker/liquibase/latest/Dockerfile.jinja2
+++ b/docker/liquibase/latest/Dockerfile.jinja2
@@ -2,7 +2,7 @@
 
 {{ docker.version() }}
 
-{{ environment.liquibase('3.5.3', 'com.mysql.jdbc.Driver', '/usr/share/java/mysql.jar') }}
+{{ environment.liquibase('3.6.3', 'com.mysql.jdbc.Driver', '/usr/share/java/mysql.jar') }}
 
 {{ docker.copy('conf/', '/opt/docker/') }}
 

--- a/docker/liquibase/mysql/Dockerfile
+++ b/docker/liquibase/mysql/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer=info@webdevops.io \
       io.webdevops.layout=8 \
       io.webdevops.version=1.5.0
 
-ENV LIQUIBASE_VERSION="3.5.3" \
+ENV LIQUIBASE_VERSION="3.6.3" \
     LIQUIBASE_DRIVER="com.mysql.jdbc.Driver" \
     LIQUIBASE_CLASSPATH="/usr/share/java/mysql.jar" \
     LIQUIBASE_URL="" \

--- a/docker/liquibase/postgres/Dockerfile
+++ b/docker/liquibase/postgres/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer=info@webdevops.io \
       io.webdevops.layout=8 \
       io.webdevops.version=1.5.0
 
-ENV LIQUIBASE_VERSION="3.5.3" \
+ENV LIQUIBASE_VERSION="3.6.3" \
     LIQUIBASE_DRIVER="org.postgresql.Driver" \
     LIQUIBASE_CLASSPATH="/usr/share/java/postgresql.jar" \
     LIQUIBASE_URL="" \

--- a/docker/liquibase/postgres/Dockerfile.jinja2
+++ b/docker/liquibase/postgres/Dockerfile.jinja2
@@ -2,7 +2,7 @@
 
 {{ docker.version() }}
 
-{{ environment.liquibase('3.5.3', 'org.postgresql.Driver', '/usr/share/java/postgresql.jar') }}
+{{ environment.liquibase('3.6.3', 'org.postgresql.Driver', '/usr/share/java/postgresql.jar') }}
 
 {{ docker.copy('conf/', '/opt/docker/') }}
 


### PR DESCRIPTION
This PR fixes duplicated migrations in <includeAll /> changeset directive by upgrading liquibase to 2.6.3 version.