### PR TITLE
Update liquibase entrypoint.sh to work with existing properties file

### DIFF
--- a/docker/liquibase/latest/conf/bin/entrypoint.sh
+++ b/docker/liquibase/latest/conf/bin/entrypoint.sh
@@ -9,8 +9,13 @@ LIQUIBASE_OPTS="$LIQUIBASE_OPTS --defaultsFile=/liquibase.properties"
 
 echo -n > /liquibase.properties
 
+if [[ -f liquibase.properties ]]; then
+    cat liquibase.properties >> /liquibase.properties
+fi
+
 ## Database driver
 if [[ -n "$LIQUIBASE_DRIVER" ]]; then
+    sed -i '/^driver:/d' /liquibase.properties
     echo "driver: ${LIQUIBASE_DRIVER}" >> /liquibase.properties
 fi
 
@@ -41,7 +46,9 @@ fi
 
 ## Database changelog file
 if [[ -n "$LIQUIBASE_CHANGELOG" ]]; then
-    echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    if ! grep -q '^changeLogFile' /liquibase.properties; then
+        echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    fi
 fi
 
 function executeLiquibase() {

--- a/docker/liquibase/mysql/conf/bin/entrypoint.sh
+++ b/docker/liquibase/mysql/conf/bin/entrypoint.sh
@@ -9,8 +9,13 @@ LIQUIBASE_OPTS="$LIQUIBASE_OPTS --defaultsFile=/liquibase.properties"
 
 echo -n > /liquibase.properties
 
+if [[ -f liquibase.properties ]]; then
+    cat liquibase.properties >> /liquibase.properties
+fi
+
 ## Database driver
 if [[ -n "$LIQUIBASE_DRIVER" ]]; then
+    sed -i '/^driver:/d' /liquibase.properties
     echo "driver: ${LIQUIBASE_DRIVER}" >> /liquibase.properties
 fi
 
@@ -41,7 +46,9 @@ fi
 
 ## Database changelog file
 if [[ -n "$LIQUIBASE_CHANGELOG" ]]; then
-    echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    if ! grep -q '^changeLogFile' /liquibase.properties; then
+        echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    fi
 fi
 
 function executeLiquibase() {

--- a/docker/liquibase/postgres/conf/bin/entrypoint.sh
+++ b/docker/liquibase/postgres/conf/bin/entrypoint.sh
@@ -9,8 +9,13 @@ LIQUIBASE_OPTS="$LIQUIBASE_OPTS --defaultsFile=/liquibase.properties"
 
 echo -n > /liquibase.properties
 
+if [[ -f liquibase.properties ]]; then
+    cat liquibase.properties >> /liquibase.properties
+fi
+
 ## Database driver
 if [[ -n "$LIQUIBASE_DRIVER" ]]; then
+    sed -i '/^driver:/d' /liquibase.properties
     echo "driver: ${LIQUIBASE_DRIVER}" >> /liquibase.properties
 fi
 
@@ -41,7 +46,9 @@ fi
 
 ## Database changelog file
 if [[ -n "$LIQUIBASE_CHANGELOG" ]]; then
-    echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    if ! grep -q '^changeLogFile' /liquibase.properties; then
+        echo "changeLogFile: ${LIQUIBASE_CHANGELOG}" >> /liquibase.properties
+    fi
 fi
 
 function executeLiquibase() {


### PR DESCRIPTION
  - If file exists, use it as the 'base' file
  - Overwrite any "driver" value
  - Don't overwrite/duplicate the changeLogFile value if specifed

This is related to #309.