### PR TITLE
debian buster: mcrypt doesn't exist in 7.3 anymore

### DIFF
--- a/docker/php/debian-10/Dockerfile
+++ b/docker/php/debian-10/Dockerfile
@@ -27,28 +27,27 @@ RUN set -x \
         apngopt \
         pngnq \
         pngquant \
-        # Install php (cli/fpm)
-        php7.3-cli \
-        php7.3-fpm \
-        php7.3-json \
-        php7.3-intl \
-        php7.3-curl \
-        php7.3-mysql \
-        php7.3-mcrypt \
-        php7.3-gd \
-        php7.3-imagick \
-        php7.3-imap \
-        php7.3-sqlite3 \
-        php7.3-pgsql \
-        php7.3-ldap \
-        php7.3-opcache \
-        php7.3-soap \
-        php7.3-zip \
-        php7.3-mbstring \
-        php7.3-bcmath \
-        php7.3-xmlrpc \
-        php7.3-xsl \
-        php7.3-bz2 \
+        # Install php (cli/fpm) | php always references the latest version
+        php-cli \
+        php-fpm \
+        php-json \
+        php-intl \
+        php-curl \
+        php-mysql \
+        php-gd \
+        php-imagick \
+        php-imap \
+        php-sqlite3 \
+        php-pgsql \
+        php-ldap \
+        php-opcache \
+        php-soap \
+        php-zip \
+        php-mbstring \
+        php-bcmath \
+        php-xmlrpc \
+        php-xsl \
+        php-bz2 \
         php-pear \
         php-apcu \
         php-redis \

--- a/documentation/docs/content/DockerImages/dockerfiles/include/image-tag-php.rst
+++ b/documentation/docs/content/DockerImages/dockerfiles/include/image-tag-php.rst
@@ -6,7 +6,7 @@ Tag                    Distribution name                   PHP Version
 ``7.1``                *customized official php image*     PHP 7.1
 ``7.2``                *customized official php image*     PHP 7.2
 ``7.3``                *customized official php image*     PHP 7.3
-``7.4``                *customized official php image*     PHP 7.4
+``7.4``                *customized official php image*     PHP 7.4 (RC)
 ``alpine``             *link to alpine-php7*               PHP 7.x
 ``alpine-php7``                                            PHP 7.x
 ``alpine-php5``                                            PHP 5.6

--- a/template/Dockerfile/images/php.jinja2
+++ b/template/Dockerfile/images/php.jinja2
@@ -145,7 +145,7 @@
 
 
 {% macro officialDevelopment(role='', version='') -%}
-{%- if version != '7.4' %}
+{% if version != '7.4' -%}
     # Install development environment
     && wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add - \
     && echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list \

--- a/template/Dockerfile/images/php7.jinja2
+++ b/template/Dockerfile/images/php7.jinja2
@@ -200,28 +200,27 @@
         apngopt \
         pngnq \
         pngquant \
-        # Install php (cli/fpm)
-        php7.3-cli \
-        php7.3-fpm \
-        php7.3-json \
-        php7.3-intl \
-        php7.3-curl \
-        php7.3-mysql \
-        php7.3-mcrypt \
-        php7.3-gd \
-        php7.3-imagick \
-        php7.3-imap \
-        php7.3-sqlite3 \
-        php7.3-pgsql \
-        php7.3-ldap \
-        php7.3-opcache \
-        php7.3-soap \
-        php7.3-zip \
-        php7.3-mbstring \
-        php7.3-bcmath \
-        php7.3-xmlrpc \
-        php7.3-xsl \
-        php7.3-bz2 \
+        # Install php (cli/fpm) | php always references the latest version
+        php-cli \
+        php-fpm \
+        php-json \
+        php-intl \
+        php-curl \
+        php-mysql \
+        php-gd \
+        php-imagick \
+        php-imap \
+        php-sqlite3 \
+        php-pgsql \
+        php-ldap \
+        php-opcache \
+        php-soap \
+        php-zip \
+        php-mbstring \
+        php-bcmath \
+        php-xmlrpc \
+        php-xsl \
+        php-bz2 \
         php-pear \
         php-apcu \
         php-redis \


### PR DESCRIPTION
This seems to be the last error i made, hopefully the pipeline now goes through