### PR TITLE
Added X Forward to apache logs

### DIFF
--- a/docker/apache/alpine/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/alpine/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/centos-7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/centos-7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/debian-10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/debian-10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/debian-7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/debian-7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/debian-8/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/debian-8/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/debian-9/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/debian-9/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-12.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-12.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-15.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-15.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-15.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-15.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-16.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-16.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-17.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-17.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-17.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-17.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/apache/ubuntu-18.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/apache/ubuntu-18.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/hhvm-apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/hhvm-apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/hhvm-apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/hhvm-apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/5.6/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/5.6/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/7.0/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/7.0/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/7.1/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/7.1/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/7.2/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/7.2/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/7.3/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/7.3/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/7.4/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/7.4/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/alpine-php5/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/alpine-php5/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/alpine-php7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/alpine-php7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/centos-7-php56/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/centos-7-php56/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/centos-7-php7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/centos-7-php7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/centos-7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/centos-7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/debian-10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/debian-10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/debian-7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/debian-7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/debian-8-php7/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/debian-8-php7/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/debian-8/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/debian-8/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/debian-9/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/debian-9/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-12.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-12.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-14.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-15.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-15.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-15.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-15.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-16.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-16.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-16.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-17.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-17.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-17.10/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-17.10/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/docker/php-apache/ubuntu-18.04/conf/etc/httpd/conf.d/10-log.conf
+++ b/docker/php-apache/ubuntu-18.04/conf/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr

--- a/provisioning/apache/general/etc/httpd/conf.d/10-log.conf
+++ b/provisioning/apache/general/etc/httpd/conf.d/10-log.conf
@@ -1,4 +1,4 @@
-LogFormat "[httpd:access] %V:%p %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
+LogFormat "[httpd:access] %V:%p %{X-Forwarded-For}i - %h %l %u %t \"%r\" %>s bytesIn:%I bytesOut:%O reqTime:%T" dockerlog
 LogLevel warn
 CustomLog /docker.stdout dockerlog
 ErrorLog  /docker.stderr


### PR DESCRIPTION
Suggest to add X Forward for header to apache logs as many website use load balancer, will return a blank value if no load balancer is used. Tested on rancher and working