### PR TITLE
remove unnecessary `cd` from typo3-solr

### DIFF
--- a/docker/typo3-solr/6.0/Dockerfile
+++ b/docker/typo3-solr/6.0/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/6.1/Dockerfile
+++ b/docker/typo3-solr/6.1/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/6.5/Dockerfile
+++ b/docker/typo3-solr/6.5/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/7.0/Dockerfile
+++ b/docker/typo3-solr/7.0/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/7.5/Dockerfile
+++ b/docker/typo3-solr/7.5/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/8.0/Dockerfile
+++ b/docker/typo3-solr/8.0/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/docker/typo3-solr/8.1/Dockerfile
+++ b/docker/typo3-solr/8.1/Dockerfile
@@ -57,7 +57,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     && docker-image-cleanup
 

--- a/template/Dockerfile/images/typo3-solr.jinja2
+++ b/template/Dockerfile/images/typo3-solr.jinja2
@@ -50,7 +50,6 @@ RUN apt-update \
     && mkdir -p /opt/solr/server/solr/data \
     && chown -R solr:solr /opt/solr/server/solr \
     && chmod 755 /opt/solr/server/solr \
-    && cd / \
     && rm -rf /tmp/solr \
     {{ docker.cleanup() }}
 


### PR DESCRIPTION
I noticed when scanning over this file that the `cd /` didn't seem to be used, so removed it. Rebuilt the images using `make full`