### PR TITLE
Remove xdebug version to enable installing latest

### DIFF
--- a/docker/php-apache-dev/7.3/Dockerfile
+++ b/docker/php-apache-dev/7.3/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && apt-install \
         blackfire-php \
         blackfire-agent \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \


### PR DESCRIPTION
Fixes perfomance degradation with getpid syscall,
see https://bugs.xdebug.org/1641

For us, performance issue was on mac for docker only, windows and linux was fast