### PR TITLE
Remove xdebug version to enable installing latest

### DIFF
--- a/docker/php-apache-dev/7.3/Dockerfile
+++ b/docker/php-apache-dev/7.3/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && apt-install \
         blackfire-php \
         blackfire-agent \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/docker/php-apache-dev/7.4/Dockerfile
+++ b/docker/php-apache-dev/7.4/Dockerfile
@@ -16,8 +16,8 @@ ENV WEB_NO_CACHE_PATTERN="\.(css|js|gif|png|jpg|svg|json|xml)$"
 COPY conf/ /opt/docker/
 
 RUN set -x \
-    
-    && pecl install xdebug-2.8.0beta1 \
+
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/docker/php-dev/7.3/Dockerfile
+++ b/docker/php-dev/7.3/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
     && apt-install \
         blackfire-php \
         blackfire-agent \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/docker/php-dev/7.4/Dockerfile
+++ b/docker/php-dev/7.4/Dockerfile
@@ -8,8 +8,8 @@ FROM webdevops/php:7.4
 COPY conf/ /opt/docker/
 
 RUN set -x \
-    
-    && pecl install xdebug-2.8.0beta1 \
+
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/docker/php-nginx-dev/7.3/Dockerfile
+++ b/docker/php-nginx-dev/7.3/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && apt-install \
         blackfire-php \
         blackfire-agent \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/docker/php-nginx-dev/7.4/Dockerfile
+++ b/docker/php-nginx-dev/7.4/Dockerfile
@@ -16,8 +16,8 @@ ENV WEB_NO_CACHE_PATTERN="\.(css|js|gif|png|jpg|svg|json|xml)$"
 COPY conf/ /opt/docker/
 
 RUN set -x \
-    
-    && pecl install xdebug-2.8.0beta1 \
+
+    && pecl install xdebug \
     && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
     # Enable php development services
     && docker-service enable syslog \

--- a/template/Dockerfile/images/php.jinja2
+++ b/template/Dockerfile/images/php.jinja2
@@ -166,10 +166,6 @@
 {%- endif %}
 {%- if version|int == 5 %}
     && pecl install xdebug-2.5.5 \
-{%- elif version == '7.3' %}
-    && pecl install xdebug-2.7.0 \
-{%- elif version == '7.4' %}
-    && pecl install xdebug-2.8.0beta1 \
 {%- else %}
     && pecl install xdebug \
 {%- endif %}


### PR DESCRIPTION
Fixes perfomance degradation with getpid syscall,
see https://bugs.xdebug.org/1641

For us, performance issue was on mac for docker only, windows and linux were fast. 
The image installs xdebug 2.7. When we installed xdebug 2.8 performance was way better.
Without the version in the image we are able to install the lates xdebug version.