### PR TITLE
WIP: Support arm64 architecture to enable usage on the current M1 MacBooks

### DIFF
--- a/docker/php-official/7.4-alpine/Dockerfile
+++ b/docker/php-official/7.4-alpine/Dockerfile
@@ -19,8 +19,9 @@ RUN mkdir -p \
     && chmod +x "/baselayout/usr/local/bin/go-replace" \
     && "/baselayout/usr/local/bin/go-replace" --version \
     # Install gosu
-    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
-    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi \
+    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}" \
+    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && gpg --batch --verify /tmp/gosu.asc "/baselayout/sbin/gosu" \

--- a/docker/php-official/7.4-alpine/Dockerfile
+++ b/docker/php-official/7.4-alpine/Dockerfile
@@ -6,6 +6,7 @@
 
 # Staged baselayout builder
 FROM webdevops/toolbox AS baselayout
+ARG TARGETPLATFORM
 RUN mkdir -p \
         /baselayout/sbin \
         /baselayout/usr/local/bin \
@@ -13,7 +14,8 @@ RUN mkdir -p \
     && wget -O /tmp/baselayout-install.sh https://raw.githubusercontent.com/webdevops/Docker-Image-Baselayout/master/install.sh \
     && sh /tmp/baselayout-install.sh /baselayout \
     ## Install go-replace
-    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/gr-64-linux" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GO_REPLACE="gr-arm64-linux"; else GO_REPLACE="gr-64-linux"; fi \
+    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/${GO_REPLACE}" \
     && chmod +x "/baselayout/usr/local/bin/go-replace" \
     && "/baselayout/usr/local/bin/go-replace" --version \
     # Install gosu

--- a/docker/php-official/7.4/Dockerfile
+++ b/docker/php-official/7.4/Dockerfile
@@ -6,6 +6,7 @@
 
 # Staged baselayout builder
 FROM webdevops/toolbox AS baselayout
+ARG TARGETPLATFORM
 RUN mkdir -p \
         /baselayout/sbin \
         /baselayout/usr/local/bin \
@@ -13,12 +14,14 @@ RUN mkdir -p \
     && wget -O /tmp/baselayout-install.sh https://raw.githubusercontent.com/webdevops/Docker-Image-Baselayout/master/install.sh \
     && sh /tmp/baselayout-install.sh /baselayout \
     ## Install go-replace
-    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/gr-64-linux" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GO_REPLACE="gr-arm64-linux"; else GO_REPLACE="gr-64-linux"; fi \
+    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/${GO_REPLACE}" \
     && chmod +x "/baselayout/usr/local/bin/go-replace" \
     && "/baselayout/usr/local/bin/go-replace" --version \
     # Install gosu
-    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
-    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi \
+    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}" \
+    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && gpg --batch --verify /tmp/gosu.asc "/baselayout/sbin/gosu" \

--- a/docker/php-official/7.4/Dockerfile
+++ b/docker/php-official/7.4/Dockerfile
@@ -105,6 +105,7 @@ RUN set -x \
     && docker-run-bootstrap \
     && docker-image-cleanup
 
+ARG TARGETPLATFORM
 RUN set -x \
     # Install php environment
     && apt-install \
@@ -164,10 +165,11 @@ RUN set -x \
     # Install extensions
     && PKG_CONFIG_PATH=/usr/local docker-php-ext-configure intl \
     && docker-php-ext-configure gd --with-jpeg --with-freetype --with-webp \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then LDAP_LIBDIR="aarch64-linux-gnu"; else LDAP_LIBDIR="x86_64-linux-gnu"; fi \
+    && docker-php-ext-configure ldap --with-libdir=lib/${LDAP_LIBDIR}/ \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install \
-        bcmath \        
+        bcmath \
         bz2 \
         calendar \
         exif \

--- a/docker/php-official/7.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -3,9 +3,10 @@
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+(uname -a | grep -q arm64) && DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz"
 TMP_FILE="/tmp/ioncube_loaders.tar.gz"
 
-echo "Downloading ..."
+echo "Downloading from ${DOWNLOAD_URL} ..."
 curl -sS ${DOWNLOAD_URL} -o ${TMP_FILE}
 echo "Unpacking ..."
 tar -xzf ${TMP_FILE} -C /tmp

--- a/docker/php-official/8.0-alpine/Dockerfile
+++ b/docker/php-official/8.0-alpine/Dockerfile
@@ -31,7 +31,6 @@ RUN mkdir -p \
 
 
 FROM php:8.0-fpm-alpine
-ARG TARGETPLATFORM
 
 LABEL maintainer=info@webdevops.io \
       vendor=WebDevOps.io \

--- a/docker/php-official/8.0-alpine/Dockerfile
+++ b/docker/php-official/8.0-alpine/Dockerfile
@@ -170,7 +170,6 @@ RUN set -x \
     # Install extensions
     && PKG_CONFIG_PATH=/usr/local docker-php-ext-configure intl \
     && docker-php-ext-configure gd --with-jpeg --with-freetype --with-webp \
-    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then LDAP_LIBDIR="aarch64-linux-gnu"; else LDAP_LIBDIR="x86_64-linux-gnu"; fi \
     && docker-php-ext-configure ldap \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install \

--- a/docker/php-official/8.0/Dockerfile
+++ b/docker/php-official/8.0/Dockerfile
@@ -6,6 +6,7 @@
 
 # Staged baselayout builder
 FROM webdevops/toolbox AS baselayout
+ARG TARGETPLATFORM
 RUN mkdir -p \
         /baselayout/sbin \
         /baselayout/usr/local/bin \
@@ -13,12 +14,14 @@ RUN mkdir -p \
     && wget -O /tmp/baselayout-install.sh https://raw.githubusercontent.com/webdevops/Docker-Image-Baselayout/master/install.sh \
     && sh /tmp/baselayout-install.sh /baselayout \
     ## Install go-replace
-    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/gr-64-linux" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GO_REPLACE="gr-arm64-linux"; else GO_REPLACE="gr-64-linux"; fi \
+    && wget -O "/baselayout/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/${GO_REPLACE}" \
     && chmod +x "/baselayout/usr/local/bin/go-replace" \
     && "/baselayout/usr/local/bin/go-replace" --version \
     # Install gosu
-    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
-    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi \
+    && wget -O "/baselayout/sbin/gosu" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}" \
+    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/1.10/gosu-${ARCH}.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && gpg --batch --verify /tmp/gosu.asc "/baselayout/sbin/gosu" \
@@ -102,6 +105,7 @@ RUN set -x \
     && docker-run-bootstrap \
     && docker-image-cleanup
 
+ARG TARGETPLATFORM
 RUN set -x \
     # Install php environment
     && apt-install \
@@ -164,7 +168,8 @@ RUN set -x \
     && git clone --branch master --depth 1 https://github.com/php-amqp/php-amqp.git /usr/src/php/ext/amqp \
     && cd /usr/src/php/ext/amqp && git submodule update --init \
     && git clone --branch master --depth 1 https://github.com/Imagick/imagick.git /usr/src/php/ext/imagick \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then LDAP_LIBDIR="aarch64-linux-gnu"; else LDAP_LIBDIR="x86_64-linux-gnu"; fi \
+    && docker-php-ext-configure ldap --with-libdir=lib/${LDAP_LIBDIR}/ \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install \
         bcmath \

--- a/docker/php-official/8.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -3,9 +3,10 @@
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+(uname -a | grep -q arm64) && DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz"
 TMP_FILE="/tmp/ioncube_loaders.tar.gz"
 
-echo "Downloading ..."
+echo "Downloading from ${DOWNLOAD_URL} ..."
 curl -sS ${DOWNLOAD_URL} -o ${TMP_FILE}
 echo "Unpacking ..."
 tar -xzf ${TMP_FILE} -C /tmp

--- a/docker/toolbox/latest/Dockerfile
+++ b/docker/toolbox/latest/Dockerfile
@@ -4,7 +4,7 @@
 #+++++++++++++++++++++++++++++++++++++++
 
 FROM alpine:latest
-
+ARG TARGETPLATFORM
 RUN apk add --no-cache \
         ca-certificates \
         openssl \
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
         git \
         gnupg \
     ## Install go-replace
-    && wget -O "/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/gr-64-linux" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GO_REPLACE="gr-arm64-linux"; else GO_REPLACE="gr-64-linux"; fi \
+    && wget -O "/usr/local/bin/go-replace" "https://github.com/webdevops/goreplace/releases/download/1.1.2/${GO_REPLACE}" \
     && chmod +x "/usr/local/bin/go-replace" \
     && "/usr/local/bin/go-replace" --version

--- a/docker/toolbox/latest/Dockerfile.jinja2
+++ b/docker/toolbox/latest/Dockerfile.jinja2
@@ -1,5 +1,5 @@
 {{ docker.fromOfficial("alpine") }}
-
+ARG TARGETPLATFORM
 RUN apk add --no-cache \
         ca-certificates \
         openssl \

--- a/provisioning/php/general/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/provisioning/php/general/provision/bootstrap.d/30-setup-ioncube.sh
@@ -3,9 +3,10 @@
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+(uname -a | grep -q arm64) && DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz"
 TMP_FILE="/tmp/ioncube_loaders.tar.gz"
 
-echo "Downloading ..."
+echo "Downloading from ${DOWNLOAD_URL} ..."
 curl -sS ${DOWNLOAD_URL} -o ${TMP_FILE}
 echo "Unpacking ..."
 tar -xzf ${TMP_FILE} -C /tmp

--- a/template/Dockerfile/baselayout.jinja2
+++ b/template/Dockerfile/baselayout.jinja2
@@ -3,6 +3,7 @@
 {% macro dockerStage() %}
 # Staged baselayout builder
 FROM webdevops/toolbox AS baselayout
+ARG TARGETPLATFORM
 RUN mkdir -p \
         /baselayout/sbin \
         /baselayout/usr/local/bin \

--- a/template/Dockerfile/images/php.jinja2
+++ b/template/Dockerfile/images/php.jinja2
@@ -71,7 +71,8 @@
     && cd /usr/src/php/ext/amqp && git submodule update --init \
     && git clone --branch master --depth 1 https://github.com/Imagick/imagick.git /usr/src/php/ext/imagick \
 {%- endif %}
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then LDAP_LIBDIR="aarch64-linux-gnu"; else LDAP_LIBDIR="x86_64-linux-gnu"; fi \
+    && docker-php-ext-configure ldap --with-libdir=lib/${LDAP_LIBDIR}/ \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install \
         bcmath \

--- a/template/Dockerfile/tools.jinja2
+++ b/template/Dockerfile/tools.jinja2
@@ -1,14 +1,16 @@
 {% macro goreplace(path="/usr/local/bin", version="1.1.2") -%}
     ## Install go-replace
-    && wget -O "{{ path }}/go-replace" "https://github.com/webdevops/goreplace/releases/download/{{ version }}/gr-64-linux" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GO_REPLACE="gr-arm64-linux"; else GO_REPLACE="gr-64-linux"; fi \
+    && wget -O "{{ path }}/go-replace" "https://github.com/webdevops/goreplace/releases/download/{{ version }}/${GO_REPLACE}" \
     && chmod +x "{{ path }}/go-replace" \
     && "{{ path }}/go-replace" --version
 {%- endmacro %}
 
-{% macro gosu(path="/sbin", arch="amd64", version="1.10") -%}
+{% macro gosu(path="/sbin", version="1.10") -%}
     # Install gosu
-    && wget -O "{{ path }}/gosu" "https://github.com/tianon/gosu/releases/download/{{ version }}/gosu-{{ arch }}" \
-    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/{{ version }}/gosu-{{ arch }}.asc" \
+    && if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi \
+    && wget -O "{{ path }}/gosu" "https://github.com/tianon/gosu/releases/download/{{ version }}/gosu-${ARCH}" \
+    && wget -O "/tmp/gosu.asc" "https://github.com/tianon/gosu/releases/download/{{ version }}/gosu-${ARCH}.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && gpg --batch --verify /tmp/gosu.asc "{{ path }}/gosu" \


### PR DESCRIPTION
This PR shows an example how to generate the dockerfiles to support arm architecture. Also it tries to give a proposal how to modify the jinja files to get the desired results. This part is actually not tested.

**Modification of dockerfile files**
I modified the Dockerfile `docker/php-official/7.4/Dockerfile`  directly to show the desired result when they are automatically generated for this example. This dockerfile can be bild on ARM (tested on the latest MacBook Pro) and also on a MacBook with Intel Chip (Tested on MacBook Pro (16-inch, 2019)).

**Modification of jinja2 files**
Without knowing if the syntax is correct i also modified the jinja templates. With the modifications the dockerfiles _should_ be generated in the shown way.

I removed the argument `arch` in the macro 'gosu(path="/sbin", arch="amd64", version="1.10")' as it is determined dynamicly during build. I did not find any usage of the argument. Hope that is ok...