### PR TITLE
Add PHP 8.1 to the docs

### DIFF
--- a/documentation/docs/content/DockerImages/dockerfiles/include/image-tag-php.rst
+++ b/documentation/docs/content/DockerImages/dockerfiles/include/image-tag-php.rst
@@ -8,6 +8,7 @@ Tag                    Distribution name                   PHP Version
 ``7.3``                *customized official php image*     PHP 7.3
 ``7.4``                *customized official php image*     PHP 7.4
 ``8.0``                *customized official php image*     PHP 8.0
+``8.1``                *customized official php image*     PHP 8.1
 ``7.1-alpine``         *customized official php image*     PHP 7.1
 ``7.2-alpine``         *customized official php image*     PHP 7.2
 ``7.3-alpine``         *customized official php image*     PHP 7.3


### PR DESCRIPTION
It has been available for a while but never added to the docs

https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-nginx.html#docker-image-tags