### PR TITLE
fix apache2 pid path for alpine

### DIFF
--- a/docker/apache/alpine/conf/bin/service.d/httpd.sh
+++ b/docker/apache/alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/docker/php-apache/7.1-alpine/conf/bin/service.d/httpd.sh
+++ b/docker/php-apache/7.1-alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/docker/php-apache/7.2-alpine/conf/bin/service.d/httpd.sh
+++ b/docker/php-apache/7.2-alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/docker/php-apache/7.3-alpine/conf/bin/service.d/httpd.sh
+++ b/docker/php-apache/7.3-alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/docker/php-apache/7.4-alpine/conf/bin/service.d/httpd.sh
+++ b/docker/php-apache/7.4-alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/docker/php-apache/8.0-alpine/conf/bin/service.d/httpd.sh
+++ b/docker/php-apache/8.0-alpine/conf/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/provisioning/apache/alpine/bin/service.d/httpd.sh
+++ b/provisioning/apache/alpine/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS

--- a/provisioning/php-apache/alpine/bin/service.d/httpd.sh
+++ b/provisioning/php-apache/alpine/bin/service.d/httpd.sh
@@ -8,6 +8,6 @@ source /opt/docker/bin/config.sh
 includeScriptDir "/opt/docker/bin/service.d/httpd.d/"
 
 # Apache gets grumpy about PID files pre-existing
-rm -f /var/run/httpd/httpd.pid
+rm -f /var/run/apache2/httpd.pid
 
 exec /usr/sbin/apachectl -DFOREGROUND $SERVICE_APACHE_OPTS


### PR DESCRIPTION
In alpine distribution, pid file is defined in `/etc/apache2/conf.d/mpm.conf` as 
```
<IfModule !mpm_netware_module>
    PidFile "/run/apache2/httpd.pid"
</IfModule>
```
the pid cleaner script uses `/var/run/httpd/http.pid` path which seems to be the path used on centos