### PR TITLE
🐛 fix alpine images

### DIFF
--- a/docker/php-official/5.6/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/5.6/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.1-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.1-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.1/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.1/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.2-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.2-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.2/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.2/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.3-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.3-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.3/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.3/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.4-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.4-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/7.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/7.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.0-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.0-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.0/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.1-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.1-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.1/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.1/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.2-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.2-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.2/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.2/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.3-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.3-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.3/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.3/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.4-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.4-alpine/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/docker/php-official/8.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/docker/php-official/8.4/conf/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"

--- a/provisioning/php/general/provision/bootstrap.d/30-setup-ioncube.sh
+++ b/provisioning/php/general/provision/bootstrap.d/30-setup-ioncube.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $IMAGE_FAMILY == "Alpine" ]; then
+    echo "Skipping ionCube installation on Alpine"
+    return
+fi
+
 echo "Installing ionCube loader"
 
 DOWNLOAD_URL="https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"


### PR DESCRIPTION
fixes: #536 alpine images build again.

IonCube already was not enabled for alpine. Now it is also not installed.